### PR TITLE
Add Docker support: Dockerfile, docker-compose.yaml, entrypoint, and …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# =============================================================================
+# .dockerignore — keeps the Docker build context small and clean
+# =============================================================================
+
+# These directories are downloaded fresh by the Dockerfile; exclude any
+# local copies to avoid stale data being baked into the image.
+bento4/
+wrapper/
+apple-music-downloader/
+
+# Runtime artefacts that must not be baked in
+firstrun
+.credentials
+downloads/
+config/
+data/
+
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Editor / OS noise
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Git history (not needed in the image)
+.git/
+.gitignore
+
+# CI / docs
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,102 @@
+# =============================================================================
+# Apple Music Downloader Web UI — Docker Image
+# =============================================================================
+# Builds a self-contained Linux container that runs the Flask web UI and all
+# required tooling (Go downloader, Bento4, Wrapper) without any host-side
+# root access beyond Docker itself.
+#
+# Build :  docker build -t alac-rip .
+# Run   :  docker run -p 5000:5000 -v "$(pwd)/downloads:/downloads" alac-rip
+# =============================================================================
+
+FROM ubuntu:22.04
+
+# ── Environment ────────────────────────────────────────────────────────────────
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    GOPATH=/root/go \
+    # Pre-set Bento4 bin + wrapper dirs in PATH so they are available even
+    # before main.py's start() function patches os.environ["PATH"].
+    PATH="/app/bento4/Bento4-SDK-1-6-0-641.x86_64-unknown-linux/bin:/app/wrapper:/root/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+WORKDIR /app
+
+# ── System packages ────────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ffmpeg \
+        gpac \
+        golang-go \
+        wget \
+        unzip \
+        python3 \
+        python3-pip \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python dependencies ────────────────────────────────────────────────────────
+RUN pip3 install --no-cache-dir flask pyyaml
+
+# ── Application source ─────────────────────────────────────────────────────────
+# Copy the repo first so that COPY layers are cached before the slow network
+# download steps that follow.
+COPY . /app/
+
+# ── Bento4 SDK ─────────────────────────────────────────────────────────────────
+# Downloaded to /app/bento4/ which is exactly where main.py expects it
+# (PROJECT_DIR / "bento4").
+RUN mkdir -p /app/bento4 \
+    && wget -q \
+        "https://www.bok.net/Bento4/binaries/Bento4-SDK-1-6-0-641.x86_64-unknown-linux.zip" \
+        -O /tmp/bento4.zip \
+    && unzip -q /tmp/bento4.zip -d /app/bento4 \
+    && rm /tmp/bento4.zip \
+    # Make every file in the extracted bin/ directory executable.
+    && find /app/bento4 -path "*/bin/*" -type f -exec chmod 755 {} \;
+
+# ── Wrapper binary ─────────────────────────────────────────────────────────────
+# The release zip may name the binary "Wrapper" (capital W); routes.py expects
+# the path  <project>/wrapper/wrapper  (lowercase w), so we create a symlink
+# when necessary.
+RUN mkdir -p /app/wrapper \
+    && wget -q \
+        "https://github.com/WorldObservationLog/wrapper/releases/download/Wrapper.x86_64.0df45b5/Wrapper.x86_64.0df45b5.zip" \
+        -O /tmp/wrapper.zip \
+    && unzip -q /tmp/wrapper.zip -d /app/wrapper \
+    && rm /tmp/wrapper.zip \
+    # Make all extracted files executable.
+    && find /app/wrapper -type f -exec chmod 755 {} \; \
+    # Normalise binary name to lowercase "wrapper" if needed.
+    && if [ ! -f /app/wrapper/wrapper ] && [ -f /app/wrapper/Wrapper ]; then \
+           ln -s /app/wrapper/Wrapper /app/wrapper/wrapper; \
+       fi
+
+# ── Apple Music Downloader (Go) ────────────────────────────────────────────────
+RUN git clone --depth 1 \
+        https://github.com/zhaarey/apple-music-downloader \
+        /app/apple-music-downloader
+
+# Pre-download Go module dependencies so the first `go run` is faster.
+RUN cd /app/apple-music-downloader \
+    && go mod download 2>/dev/null || echo "[docker-build] go mod download skipped — will run at first use"
+
+# ── First-run marker ───────────────────────────────────────────────────────────
+# main.py skips the firstsetup() function when this file is present, because
+# all setup has already been performed by the Dockerfile above.
+RUN touch /app/firstrun
+
+# ── Downloads directory ────────────────────────────────────────────────────────
+# Default download target; mount a host directory here to persist files.
+RUN mkdir -p /downloads/alac /downloads/atmos /downloads/aac
+
+# ── Entrypoint ─────────────────────────────────────────────────────────────────
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 5000
+
+# Declare the downloads directory as a named volume so users can easily
+# mount it: -v my_downloads:/downloads
+VOLUME ["/downloads"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/app/routes.py
+++ b/app/routes.py
@@ -13,6 +13,9 @@ wrapper_running = False
 wrapper_needs_2fa = False
 download_process = None
 download_running = False
+_auto_login_started = False  # prevent duplicate threads on rapid page refreshes
+
+LOG_MAX = 500  # maximum lines kept in memory per log list
 
 def stream_download_logs(pipe, target_list):
     """Thread target to read logs from download process and store them."""
@@ -23,8 +26,9 @@ def stream_download_logs(pipe, target_list):
             line = line.strip()
             if line:
                 target_list.append(line)
-                print(f"[DOWNLOAD LOG] {line}")  # Debug print
-                    
+                if len(target_list) > LOG_MAX:
+                    del target_list[0]
+
     except Exception as e:
         target_list.append(f"Error reading download logs: {str(e)}")
     finally:
@@ -48,7 +52,8 @@ def stream_wrapper_logs(pipe, target_list, email=None, password=None, auto_login
             line = line.strip()
             if line:
                 target_list.append(line)
-                print(f"[WRAPPER LOG] {line}")  # Debug print
+                if len(target_list) > LOG_MAX:
+                    del target_list[0]
                 
                 # Check for 2FA requirement
                 if "credentialHandler:" in line and "2FA: true" in line:
@@ -100,7 +105,13 @@ wrapper_logs = []
 downloader_logs = []
 
 def get_credentials_path():
-    """Get the path to the credentials file"""
+    """Get the path to the credentials file.
+    Override with CREDENTIALS_PATH env var (used in Docker to point at a
+    mounted volume so credentials survive container restarts).
+    """
+    env_path = os.environ.get("CREDENTIALS_PATH")
+    if env_path:
+        return env_path
     script_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     return os.path.join(script_dir, ".credentials")
 
@@ -145,10 +156,14 @@ def delete_credentials():
 
 def attempt_auto_login():
     """Try to automatically login with saved credentials"""
+    global _auto_login_started
     email, password = load_credentials()
     if email and password:
         wrapper_logs.append("Found saved credentials, attempting auto-login...")
-        return start_wrapper_login(email, password, auto_login=True)
+        result = start_wrapper_login(email, password, auto_login=True)
+        _auto_login_started = False
+        return result
+    _auto_login_started = False
     return False
 
 def start_wrapper_login(email, password, auto_login=False):
@@ -172,7 +187,7 @@ def start_wrapper_login(email, password, auto_login=False):
     wrapper_path = os.path.join(wrapper_dir, "wrapper")
     
     cmd = [wrapper_path, "-L", f"{email}:{password}"]
-    wrapper_logs.append(f"{prefix}Executing: {' '.join(cmd)}")
+    wrapper_logs.append(f"{prefix}Executing: {wrapper_path} -L [credentials hidden]")
     wrapper_logs.append(f"{prefix}Working directory: {wrapper_dir}")
     
     try:
@@ -202,12 +217,17 @@ def start_wrapper_login(email, password, auto_login=False):
 
 @app.route("/")
 def index():
-    # Check for saved credentials and attempt auto-login on first load
+    global _auto_login_started
+    # Attempt auto-login once on startup; guard against spawning multiple
+    # threads when the user refreshes the page during the login sequence.
     email, password = load_credentials()
-    if email and password and not wrapper_running and (not wrapper_process or wrapper_process.poll() is not None):
-        # Attempt auto-login in a separate thread to not block page load
+    if (email and password
+            and not wrapper_running
+            and not _auto_login_started
+            and (not wrapper_process or wrapper_process.poll() is not None)):
+        _auto_login_started = True
         threading.Thread(target=attempt_auto_login, daemon=True).start()
-    
+
     return render_template("index.html", wrapper_running=wrapper_running, has_saved_credentials=email is not None, saved_email=email if email else "")
 
 
@@ -333,7 +353,7 @@ def get_logs():
 @app.route("/stop_wrapper", methods=["POST"])
 def stop_wrapper():
     global wrapper_process, wrapper_running, wrapper_logs, wrapper_needs_2fa
-    
+
     if wrapper_process and wrapper_process.poll() is None:
         wrapper_process.terminate()
         wrapper_logs.append("Wrapper process terminated by user")
@@ -342,6 +362,29 @@ def stop_wrapper():
         return jsonify({"status": "ok", "msg": "Wrapper stopped"})
     else:
         return jsonify({"status": "error", "msg": "Wrapper not running"})
+
+@app.route("/stop_download", methods=["POST"])
+def stop_download():
+    global download_process, download_running, downloader_logs
+
+    if download_process and download_process.poll() is None:
+        download_process.terminate()
+        downloader_logs.append("Download cancelled by user")
+        download_running = False
+        return jsonify({"status": "ok", "msg": "Download stopped"})
+    else:
+        return jsonify({"status": "error", "msg": "No download in progress"})
+
+@app.route("/clear_logs", methods=["POST"])
+def clear_logs():
+    global wrapper_logs, downloader_logs
+
+    target = request.json.get("target", "all") if request.json else "all"
+    if target in ("wrapper", "all"):
+        wrapper_logs.clear()
+    if target in ("downloader", "all"):
+        downloader_logs.clear()
+    return jsonify({"status": "ok"})
 
 @app.route("/settings")
 def settings():

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2,26 +2,40 @@ body {
     font-family: "Segoe UI", sans-serif;
 }
 
+/* ── Log box ─────────────────────────────────────────────────────────────────── */
+
 .log-box {
     background: #111;
     border: 1px solid #444;
-    padding: 10px;
-    height: 200px;
+    padding: 8px 10px;
+    height: 350px;
     overflow-y: auto;
     font-family: monospace;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
+    line-height: 1.5;
     white-space: pre-wrap;
-    border-radius: 8px;
+    border-radius: 6px;
 }
 
-/* 2FA Modal Styles */
+.log-box div {
+    padding: 1px 0;
+}
+
+/* Colour-coded log line classes */
+.log-ok   { color: #28a745; }
+.log-err  { color: #dc3545; }
+.log-info { color: #17a2b8; }
+.log-warn { color: #ffc107; }
+
+/* ── 2FA modal ───────────────────────────────────────────────────────────────── */
+
 .modal-overlay {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.75);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -37,7 +51,7 @@ body {
     max-width: 450px;
     width: 90%;
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
-    animation: modalSlideIn 0.3s ease-out;
+    animation: modalSlideIn 0.25s ease-out;
     color: white;
 }
 
@@ -68,7 +82,7 @@ body {
     color: white;
     font-size: 1.2rem;
     letter-spacing: 2px;
-    transition: all 0.3s ease;
+    transition: border-color 0.2s ease, background 0.2s ease;
 }
 
 .modal-body input:focus {
@@ -77,17 +91,7 @@ body {
     box-shadow: 0 0 10px rgba(0, 212, 255, 0.3);
 }
 
-.gap-2 {
-    gap: 0.5rem !important;
-}
-
 @keyframes modalSlideIn {
-    from {
-        opacity: 0;
-        transform: translateY(-30px) scale(0.95);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-    }
+    from { opacity: 0; transform: translateY(-20px) scale(0.97); }
+    to   { opacity: 1; transform: translateY(0)    scale(1);     }
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,49 +10,37 @@
 <body class="bg-dark text-light">
 
 <div class="container-fluid p-3">
-    <!-- Title Section -->
-    <div class="text-center mb-4">
-        <h1 class="display-4 text-primary mb-2">
-            🎵 Apple Music Downloader Web UI
-        </h1>
-        <p class="lead text-muted mb-3">
-            A simple web interface for downloading your favorite Apple Music tracks
-        </p>
-        <div class="mb-3">
-            <a href="https://github.com/lalit22km/apple-music-dl-ui" target="_blank" class="btn btn-outline-warning btn-sm">
-                ⭐ Star this project on GitHub
-            </a>
-        </div>
+    <!-- Title -->
+    <div class="text-center mb-3">
+        <h1 class="display-5 text-primary mb-1">🎵 Apple Music Downloader</h1>
+        <p class="text-muted small mb-0">Web UI for apple-music-downloader</p>
     </div>
 
     <!-- Top bar -->
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <div>
-            <button class="btn btn-outline-light" onclick="window.location.href='/settings'">⚙ Settings</button>
-        </div>
-        <div>
-            <span id="wrapper-indicator"
-                  class="badge {{ 'bg-success' if wrapper_running else 'bg-danger' }}">
-                Wrapper: {{ 'Running' if wrapper_running else 'Stopped' }}
-            </span>
-        </div>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <button class="btn btn-outline-light btn-sm" onclick="window.location.href='/settings'">⚙ Settings</button>
+        <span id="wrapper-indicator" class="badge {{ 'bg-success' if wrapper_running else 'bg-danger' }}">
+            Wrapper: {{ 'Running' if wrapper_running else 'Stopped' }}
+        </span>
     </div>
 
     <!-- Login Section -->
     <div class="text-center mb-3">
-        <button id="login-btn" class="btn btn-secondary">Login to Wrapper</button>
-        <button id="stop-wrapper-btn" class="btn btn-danger ms-2 d-none">Stop Wrapper</button>
-        <button id="auto-login-btn" class="btn btn-info ms-2 d-none">🤖 Auto Login</button>
-        <button id="forget-credentials-btn" class="btn btn-warning ms-2 d-none">🗑️ Forget Credentials</button>
-        
+        <button id="login-btn" class="btn btn-secondary btn-sm">Login to Wrapper</button>
+        <button id="stop-wrapper-btn" class="btn btn-danger btn-sm ms-2 d-none">Stop Wrapper</button>
+        <button id="auto-login-btn" class="btn btn-info btn-sm ms-2 d-none">🤖 Auto Login</button>
+        <button id="forget-credentials-btn" class="btn btn-warning btn-sm ms-2 d-none">🗑 Forget Saved Login</button>
+
         <div id="saved-credentials-info" class="mt-2 d-none">
             <small class="text-success">💾 Saved credentials for: <span id="saved-email-display"></span></small>
         </div>
-        
+
         <div id="login-form" class="mt-3 d-none">
-            <input type="email" id="email" placeholder="Email" class="form-control mb-2 w-25 mx-auto">
-            <input type="password" id="password" placeholder="Password" class="form-control mb-2 w-25 mx-auto">
-            <button id="submit-login" class="btn btn-success">Login</button>
+            <input type="email" id="email" placeholder="Apple ID email"
+                   class="form-control mb-2 w-25 mx-auto" autocomplete="username">
+            <input type="password" id="password" placeholder="Password"
+                   class="form-control mb-2 w-25 mx-auto" autocomplete="current-password">
+            <button id="submit-login" class="btn btn-success btn-sm">Login</button>
         </div>
     </div>
 
@@ -64,7 +52,10 @@
             </div>
             <div class="modal-body">
                 <p class="text-center mb-3">Please enter your 2FA code to continue:</p>
-                <input type="text" id="twofa-code" placeholder="Enter 2FA Code" class="form-control form-control-lg text-center mb-3" maxlength="6" autocomplete="off" pattern="[0-9]*" inputmode="numeric">
+                <input type="text" id="twofa-code" placeholder="Enter 2FA Code"
+                       class="form-control form-control-lg text-center mb-3"
+                       maxlength="6" autocomplete="one-time-code"
+                       pattern="[0-9]*" inputmode="numeric">
                 <div class="d-flex justify-content-center gap-2">
                     <button id="submit-2fa" class="btn btn-success">Submit</button>
                     <button id="cancel-2fa" class="btn btn-secondary">Cancel</button>
@@ -73,9 +64,10 @@
         </div>
     </div>
 
-    <!-- Middle input area -->
-    <div class="text-center mb-4">
-        <input id="link-box" type="text" class="form-control form-control-lg mb-3 w-50 mx-auto"
+    <!-- Download controls -->
+    <div class="text-center mb-3">
+        <input id="link-box" type="text"
+               class="form-control form-control-lg mb-3 w-50 mx-auto"
                placeholder="Paste Apple Music link here">
 
         <div class="d-flex justify-content-center align-items-center mb-3">
@@ -84,9 +76,10 @@
                 <label class="form-check-label" for="special-audio">Special Audio</label>
             </div>
         </div>
-        
+
         <div class="d-flex justify-content-center mb-3">
-            <div id="format-options" class="border rounded p-3" style="background-color: #333; border-color: #555; max-width: 300px;">
+            <div id="format-options" class="border rounded p-2"
+                 style="background-color: #333; border-color: #555;">
                 <div class="form-check form-check-inline">
                     <input class="form-check-input" type="radio" name="format" id="atmos" value="ATMOS" checked>
                     <label class="form-check-label" for="atmos">ATMOS</label>
@@ -98,377 +91,309 @@
             </div>
         </div>
 
-        <div class="mt-3">
-            <button id="download-btn" class="btn btn-primary btn-lg" disabled>Download</button>
-        </div>
+        <button id="download-btn" class="btn btn-primary" disabled>Download</button>
+        <button id="stop-download-btn" class="btn btn-danger ms-2 d-none">⏹ Stop Download</button>
     </div>
 
-    <!-- Download Folders Info -->
-    <div class="row mb-4" id="download-folders-info" style="display: none;">
+    <!-- Download folder locations -->
+    <div class="row mb-3" id="download-folders-info">
         <div class="col-12">
-            <div class="alert alert-info">
-                <h6 class="mb-2">📁 Download Locations:</h6>
-                <div class="row">
-                    <div class="col-md-4">
-                        <small><strong>ALAC:</strong> <span id="alac-folder"></span></small>
-                    </div>
-                    <div class="col-md-4">
-                        <small><strong>ATMOS:</strong> <span id="atmos-folder"></span></small>
-                    </div>
-                    <div class="col-md-4">
-                        <small><strong>AAC:</strong> <span id="aac-folder"></span></small>
-                    </div>
-                </div>
+            <div class="alert alert-secondary py-2 mb-0">
+                <span class="fw-semibold">📁 Save locations: </span>
+                <span class="text-muted small">
+                    ALAC: <span id="alac-folder" class="text-light">…</span> &nbsp;|&nbsp;
+                    ATMOS: <span id="atmos-folder" class="text-light">…</span> &nbsp;|&nbsp;
+                    AAC: <span id="aac-folder" class="text-light">…</span>
+                </span>
             </div>
         </div>
     </div>
 
-    <!-- Bottom logs -->
-    <div class="row">
+    <!-- Logs -->
+    <div class="row g-3">
         <div class="col-md-6">
-            <h5>Downloader Logs</h5>
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <h6 class="mb-0">Downloader Logs</h6>
+                <button class="btn btn-outline-secondary btn-sm py-0"
+                        onclick="clearLogs('downloader')">Clear</button>
+            </div>
             <div class="log-box" id="downloader-logs"></div>
         </div>
         <div class="col-md-6">
-            <h5>Wrapper Logs</h5>
+            <div class="d-flex justify-content-between align-items-center mb-1">
+                <h6 class="mb-0">Wrapper Logs</h6>
+                <button class="btn btn-outline-secondary btn-sm py-0"
+                        onclick="clearLogs('wrapper')">Clear</button>
+            </div>
             <div class="log-box" id="wrapper-logs"></div>
         </div>
     </div>
 </div>
 
 <script>
-// Check for saved credentials on page load
-function checkSavedCredentials() {
-    axios.get('/check_saved_credentials')
-        .then(res => {
-            if (res.data.has_credentials) {
-                document.getElementById('saved-credentials-info').classList.remove('d-none');
-                document.getElementById('saved-email-display').textContent = res.data.email;
-                document.getElementById('auto-login-btn').classList.remove('d-none');
-                document.getElementById('forget-credentials-btn').classList.remove('d-none');
-            }
-        });
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Escape a string so it is safe to inject into innerHTML. */
+function e(str) {
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
 }
 
-// Auto-login functionality
-document.getElementById('auto-login-btn').addEventListener('click', () => {
-    const wrapperLogs = document.getElementById('wrapper-logs');
-    wrapperLogs.innerHTML += `<div>> 🤖 Starting auto-login...</div>`;
-    wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-    
-    axios.post('/auto_login')
-        .then(res => {
-            if (res.data.status === 'ok') {
-                wrapperLogs.innerHTML += `<div>> ${res.data.msg}</div>`;
-            } else {
-                wrapperLogs.innerHTML += `<div>> ❌ ${res.data.msg}</div>`;
-            }
-            wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-        });
-});
+/** Append a single pre-escaped line to a log box and auto-scroll. */
+function appendLog(boxId, html) {
+    const box = document.getElementById(boxId);
+    box.innerHTML += html;
+    box.scrollTop = box.scrollHeight;
+}
 
-// Forget credentials functionality
-document.getElementById('forget-credentials-btn').addEventListener('click', () => {
-    if (confirm('Are you sure you want to delete saved credentials?')) {
-        axios.post('/delete_saved_credentials')
-            .then(res => {
-                if (res.data.status === 'ok') {
-                    document.getElementById('saved-credentials-info').classList.add('d-none');
-                    document.getElementById('auto-login-btn').classList.add('d-none');
-                    document.getElementById('forget-credentials-btn').classList.add('d-none');
-                    
-                    const wrapperLogs = document.getElementById('wrapper-logs');
-                    wrapperLogs.innerHTML += `<div>> 🗑️ Saved credentials deleted</div>`;
-                    wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-                }
-            });
+/** Render a full log line with colour coding. Returns an HTML string. */
+function renderLine(line, type) {
+    const safe = e(line);
+    if (line.includes('✅') || line.includes('completed successfully') || line.includes('Ready for downloads') || line.includes('response type 6')) {
+        return `<div class="log-ok">&gt; ${safe}</div>`;
     }
+    if (line.includes('❌') || line.includes('Login failed') || line.includes('ERROR') || line.includes('failed') || line.includes('Error')) {
+        return `<div class="log-err">&gt; ${safe}</div>`;
+    }
+    if (line.includes('🎵') || line.includes('Starting')) {
+        return `<div class="log-info">&gt; ${safe}</div>`;
+    }
+    return `<div>&gt; ${safe}</div>`;
+}
+
+// ── Saved-credentials UI ──────────────────────────────────────────────────────
+
+function checkSavedCredentials() {
+    axios.get('/check_saved_credentials').then(res => {
+        if (res.data.has_credentials) {
+            document.getElementById('saved-credentials-info').classList.remove('d-none');
+            document.getElementById('saved-email-display').textContent = res.data.email;
+            document.getElementById('auto-login-btn').classList.remove('d-none');
+            document.getElementById('forget-credentials-btn').classList.remove('d-none');
+        }
+    });
+}
+
+document.getElementById('auto-login-btn').addEventListener('click', () => {
+    appendLog('wrapper-logs', '<div class="log-info">&gt; 🤖 Starting auto-login…</div>');
+    axios.post('/auto_login').then(res => {
+        const cls = res.data.status === 'ok' ? 'log-info' : 'log-err';
+        appendLog('wrapper-logs', `<div class="${cls}">&gt; ${e(res.data.msg)}</div>`);
+    });
 });
 
-document.getElementById("login-btn").addEventListener("click", () => {
-    document.getElementById("login-form").classList.toggle("d-none");
+document.getElementById('forget-credentials-btn').addEventListener('click', () => {
+    if (!confirm('Delete saved credentials?')) return;
+    axios.post('/delete_saved_credentials').then(res => {
+        if (res.data.status === 'ok') {
+            document.getElementById('saved-credentials-info').classList.add('d-none');
+            document.getElementById('auto-login-btn').classList.add('d-none');
+            document.getElementById('forget-credentials-btn').classList.add('d-none');
+            appendLog('wrapper-logs', '<div>&gt; 🗑 Saved credentials deleted</div>');
+        }
+    });
 });
 
-document.getElementById("submit-login").addEventListener("click", () => {
-    const email = document.getElementById("email").value;
-    const password = document.getElementById("password").value;
-    
-    // Add immediate feedback
-    const wrapperLogs = document.getElementById("wrapper-logs");
-    wrapperLogs.innerHTML += `<div>> Attempting to login with ${email}...</div>`;
-    wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
+// ── Login form ────────────────────────────────────────────────────────────────
 
-    axios.post("/login_wrapper", new URLSearchParams({email, password}))
+document.getElementById('login-btn').addEventListener('click', () => {
+    document.getElementById('login-form').classList.toggle('d-none');
+});
+
+document.getElementById('submit-login').addEventListener('click', () => {
+    const email    = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+    if (!email || !password) {
+        appendLog('wrapper-logs', '<div class="log-err">&gt; Please enter email and password</div>');
+        return;
+    }
+    appendLog('wrapper-logs', `<div>&gt; Attempting to login with ${e(email)}…</div>`);
+    axios.post('/login_wrapper', new URLSearchParams({email, password}))
         .then(res => {
-            if (res.data.status === "ok") {
-                // Don't immediately set as running - wait for the success message in logs
-                wrapperLogs.innerHTML += `<div>> ${res.data.msg}</div>`;
-            } else {
-                wrapperLogs.innerHTML += `<div>> ERROR: ${res.data.msg}</div>`;
-            }
-            wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
+            const cls = res.data.status === 'ok' ? '' : 'log-err';
+            appendLog('wrapper-logs', `<div class="${cls}">&gt; ${e(res.data.msg)}</div>`);
         })
-        .catch(err => {
-            wrapperLogs.innerHTML += `<div>> ERROR: Failed to connect to server</div>`;
-            wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-        });
+        .catch(() => appendLog('wrapper-logs', '<div class="log-err">&gt; ERROR: Failed to connect to server</div>'));
 });
 
-document.getElementById("download-btn").addEventListener("click", () => {
-    const link = document.getElementById("link-box").value;
-    const format = document.querySelector("input[name='format']:checked")?.value || "ATMOS";
-    const specialAudio = document.getElementById("special-audio").checked;
-    
-    if (!link.trim()) {
-        const logs = document.getElementById("downloader-logs");
-        logs.innerHTML += `<div style="color: #dc3545;"> ❌ Please enter a valid Apple Music URL</div>`;
-        logs.scrollTop = logs.scrollHeight;
+// ── Download ──────────────────────────────────────────────────────────────────
+
+document.getElementById('download-btn').addEventListener('click', () => {
+    const link        = document.getElementById('link-box').value.trim();
+    const format      = document.querySelector("input[name='format']:checked")?.value || 'ATMOS';
+    const specialAudio = document.getElementById('special-audio').checked;
+
+    if (!link) {
+        appendLog('downloader-logs', '<div class="log-err">&gt; ❌ Please enter a valid Apple Music URL</div>');
         return;
     }
 
-    const formData = new URLSearchParams({
-        link: link,
-        format: format,
-        special_audio: specialAudio
-    });
-
-    axios.post("/download", formData)
+    axios.post('/download', new URLSearchParams({link, format, special_audio: specialAudio}))
         .then(res => {
-            const logs = document.getElementById("downloader-logs");
-            if (res.data.status === "ok") {
-                logs.innerHTML += `<div style="color: #28a745;"> ✅ ${res.data.msg}</div>`;
-                // Disable download button while download is running
-                document.getElementById("download-btn").disabled = true;
-                document.getElementById("download-btn").textContent = "Downloading...";
+            if (res.data.status === 'ok') {
+                appendLog('downloader-logs', `<div class="log-ok">&gt; ✅ ${e(res.data.msg)}</div>`);
             } else {
-                logs.innerHTML += `<div style="color: #dc3545;"> ❌ ${res.data.msg}</div>`;
+                appendLog('downloader-logs', `<div class="log-err">&gt; ❌ ${e(res.data.msg)}</div>`);
             }
-            logs.scrollTop = logs.scrollHeight;
         })
-        .catch(err => {
-            const logs = document.getElementById("downloader-logs");
-            logs.innerHTML += `<div style="color: #dc3545;"> ❌ Failed to start download</div>`;
-            logs.scrollTop = logs.scrollHeight;
-        });
+        .catch(() => appendLog('downloader-logs', '<div class="log-err">&gt; ❌ Failed to start download</div>'));
 });
 
-document.getElementById("stop-wrapper-btn").addEventListener("click", () => {
-    axios.post("/stop_wrapper")
-        .then(res => {
-            const wrapperLogs = document.getElementById("wrapper-logs");
-            wrapperLogs.innerHTML += `<div>> ${res.data.msg}</div>`;
-            wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-            
-            if (res.data.status === "ok") {
-                updateWrapperStatus(false);
-            }
-        });
+document.getElementById('stop-download-btn').addEventListener('click', () => {
+    axios.post('/stop_download').then(res => {
+        const cls = res.data.status === 'ok' ? 'log-info' : 'log-err';
+        appendLog('downloader-logs', `<div class="${cls}">&gt; ${e(res.data.msg)}</div>`);
+    });
 });
+
+document.getElementById('stop-wrapper-btn').addEventListener('click', () => {
+    axios.post('/stop_wrapper').then(res => {
+        appendLog('wrapper-logs', `<div>&gt; ${e(res.data.msg)}</div>`);
+        if (res.data.status === 'ok') updateWrapperStatus(false);
+    });
+});
+
+// ── Clear logs ────────────────────────────────────────────────────────────────
+
+function clearLogs(target) {
+    axios.post('/clear_logs', {target}, {headers: {'Content-Type': 'application/json'}})
+        .then(() => {
+            if (target === 'downloader' || target === 'all')
+                document.getElementById('downloader-logs').innerHTML = '';
+            if (target === 'wrapper' || target === 'all')
+                document.getElementById('wrapper-logs').innerHTML = '';
+        });
+}
+
+// ── Status + polling ──────────────────────────────────────────────────────────
 
 function updateWrapperStatus(running) {
-    const indicator = document.getElementById("wrapper-indicator");
-    const downloadBtn = document.getElementById("download-btn");
-    const stopBtn = document.getElementById("stop-wrapper-btn");
-    
+    const indicator   = document.getElementById('wrapper-indicator');
+    const downloadBtn = document.getElementById('download-btn');
+    const stopBtn     = document.getElementById('stop-wrapper-btn');
+
     if (running) {
-        indicator.className = "badge bg-success";
-        indicator.innerText = "Wrapper: Running";
-        downloadBtn.disabled = false;
-        stopBtn.classList.remove("d-none");
+        indicator.className = 'badge bg-success';
+        indicator.textContent = 'Wrapper: Running';
+        stopBtn.classList.remove('d-none');
     } else {
-        indicator.className = "badge bg-danger";
-        indicator.innerText = "Wrapper: Stopped";
+        indicator.className = 'badge bg-danger';
+        indicator.textContent = 'Wrapper: Stopped';
         downloadBtn.disabled = true;
-        stopBtn.classList.add("d-none");
+        stopBtn.classList.add('d-none');
+    }
+}
+
+function updateDownloadStatus(running, wrapperRunning) {
+    const downloadBtn  = document.getElementById('download-btn');
+    const stopDlBtn    = document.getElementById('stop-download-btn');
+
+    if (running) {
+        downloadBtn.disabled = true;
+        downloadBtn.textContent = 'Downloading…';
+        stopDlBtn.classList.remove('d-none');
+    } else {
+        downloadBtn.disabled = !wrapperRunning;
+        downloadBtn.textContent = 'Download';
+        stopDlBtn.classList.add('d-none');
     }
 }
 
 function updateLogs() {
-    axios.get("/get_logs").then(res => {
-        const wrapperBox = document.getElementById("wrapper-logs");
-        const downloaderBox = document.getElementById("downloader-logs");
-        const downloadBtn = document.getElementById("download-btn");
+    axios.get('/get_logs').then(res => {
+        const wBox = document.getElementById('wrapper-logs');
+        const dBox = document.getElementById('downloader-logs');
 
-        // Only update if there are actually logs to show
         if (res.data.wrapper.length > 0) {
-            // Color-code success and error messages
-            wrapperBox.innerHTML = res.data.wrapper.map(l => {
-                if (l.includes("✅") || l.includes("Ready for downloads")) {
-                    return `<div style="color: #28a745;">> ${l}</div>`;
-                } else if (l.includes("❌") || l.includes("Login failed") || l.includes("ERROR")) {
-                    return `<div style="color: #dc3545;">> ${l}</div>`;
-                } else if (l.includes("[.] response type 6")) {
-                    return `<div style="color: #28a745; font-weight: bold;">> ${l}</div>`;
-                } else {
-                    return `<div>> ${l}</div>`;
-                }
-            }).join("");
-            wrapperBox.scrollTop = wrapperBox.scrollHeight;
+            wBox.innerHTML = res.data.wrapper.map(l => renderLine(l, 'wrapper')).join('');
+            wBox.scrollTop = wBox.scrollHeight;
         }
-        
         if (res.data.downloader.length > 0) {
-            // Color-code download messages
-            downloaderBox.innerHTML = res.data.downloader.map(l => {
-                if (l.includes("✅") || l.includes("completed successfully")) {
-                    return `<div style="color: #28a745;">> ${l}</div>`;
-                } else if (l.includes("❌") || l.includes("failed") || l.includes("Error")) {
-                    return `<div style="color: #dc3545;">> ${l}</div>`;
-                } else if (l.includes("🎵") || l.includes("Starting")) {
-                    return `<div style="color: #17a2b8;">> ${l}</div>`;
-                } else {
-                    return `<div>> ${l}</div>`;
-                }
-            }).join("");
-            downloaderBox.scrollTop = downloaderBox.scrollHeight;
+            dBox.innerHTML = res.data.downloader.map(l => renderLine(l, 'downloader')).join('');
+            dBox.scrollTop = dBox.scrollHeight;
         }
-        
-        // Update download button state based on download status
-        if (res.data.download_running) {
-            downloadBtn.disabled = true;
-            downloadBtn.textContent = "Downloading...";
-        } else {
-            if (res.data.wrapper_running) {
-                downloadBtn.disabled = false;
-                downloadBtn.textContent = "Download";
-            }
-        }
-        
-        // Update wrapper status based on server response
+
         updateWrapperStatus(res.data.wrapper_running);
-        
-        // Check for 2FA requirement
+        updateDownloadStatus(res.data.download_running, res.data.wrapper_running);
+
+        // 2FA modal
+        const modal = document.getElementById('twofa-modal');
         if (res.data.wrapper_needs_2fa) {
-            const modal = document.getElementById('twofa-modal');
-            if (modal.classList.contains('d-none')) {
-                show2FAModal();
-            }
+            if (modal.classList.contains('d-none')) show2FAModal();
         } else {
-            // Hide 2FA modal if no longer needed
-            const modal = document.getElementById('twofa-modal');
-            if (!modal.classList.contains('d-none')) {
-                hide2FAModal();
-            }
+            if (!modal.classList.contains('d-none')) hide2FAModal();
         }
-        
-    }).catch(err => {
-        console.log("Error fetching logs:", err);
-    });
+    }).catch(() => {});
 }
 
-// Start polling immediately and then every 1 second for better responsiveness
-updateLogs();
 setInterval(updateLogs, 1000);
-
-// Check for saved credentials when page loads
+updateLogs();
 checkSavedCredentials();
 
-// Load download folders
-function loadDownloadFolders() {
-    axios.get('/get_download_folders')
-        .then(res => {
-            if (res.data.status === 'ok') {
-                document.getElementById('alac-folder').textContent = res.data.folders.alac;
-                document.getElementById('atmos-folder').textContent = res.data.folders.atmos;
-                document.getElementById('aac-folder').textContent = res.data.folders.aac;
-                document.getElementById('download-folders-info').style.display = 'block';
-            }
-        })
-        .catch(err => {
-            console.log('Error loading download folders:', err);
-        });
-}
+// ── Download folder paths ─────────────────────────────────────────────────────
 
-// Load download folders on page load
-loadDownloadFolders();
-
-// Handle Special Audio checkbox toggle
-document.getElementById('special-audio').addEventListener('change', function() {
-    const formatOptions = document.getElementById('format-options');
-    const radioButtons = formatOptions.querySelectorAll('input[type="radio"]');
-    
-    if (this.checked) {
-        formatOptions.style.opacity = '1';
-        radioButtons.forEach(radio => radio.disabled = false);
-    } else {
-        formatOptions.style.opacity = '0.5';
-        radioButtons.forEach(radio => radio.disabled = true);
+axios.get('/get_download_folders').then(res => {
+    if (res.data.status === 'ok') {
+        document.getElementById('alac-folder').textContent  = res.data.folders.alac;
+        document.getElementById('atmos-folder').textContent = res.data.folders.atmos;
+        document.getElementById('aac-folder').textContent   = res.data.folders.aac;
     }
+}).catch(() => {});
+
+// ── Special audio toggle ──────────────────────────────────────────────────────
+
+document.getElementById('special-audio').addEventListener('change', function () {
+    const opts   = document.getElementById('format-options');
+    const radios = opts.querySelectorAll('input[type="radio"]');
+    opts.style.opacity = this.checked ? '1' : '0.5';
+    radios.forEach(r => r.disabled = !this.checked);
 });
 
-// 2FA Modal Functionality
+// ── 2FA modal ─────────────────────────────────────────────────────────────────
+
 function show2FAModal() {
-    const modal = document.getElementById('twofa-modal');
-    const codeInput = document.getElementById('twofa-code');
-    modal.classList.remove('d-none');
-    setTimeout(() => codeInput.focus(), 100);
+    document.getElementById('twofa-modal').classList.remove('d-none');
+    setTimeout(() => document.getElementById('twofa-code').focus(), 100);
 }
 
 function hide2FAModal() {
-    const modal = document.getElementById('twofa-modal');
-    const codeInput = document.getElementById('twofa-code');
-    modal.classList.add('d-none');
-    codeInput.value = '';
+    document.getElementById('twofa-modal').classList.add('d-none');
+    document.getElementById('twofa-code').value = '';
 }
 
-// Submit 2FA Code
-document.getElementById('submit-2fa').addEventListener('click', function() {
+document.getElementById('submit-2fa').addEventListener('click', () => {
     const code = document.getElementById('twofa-code').value.trim();
-    
-    if (!code) {
-        alert('Please enter your 2FA code');
-        return;
-    }
-    
-    const wrapperLogs = document.getElementById('wrapper-logs');
-    wrapperLogs.innerHTML += `<div style="color: #17a2b8;">> 🔐 Submitting 2FA code...</div>`;
-    wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-    
+    if (!code) { alert('Please enter your 2FA code'); return; }
+
+    appendLog('wrapper-logs', '<div class="log-info">&gt; 🔐 Submitting 2FA code…</div>');
     axios.post('/submit_2fa', new URLSearchParams({twofa_code: code}))
         .then(res => {
             if (res.data.status === 'ok') {
-                wrapperLogs.innerHTML += `<div style="color: #28a745;">> ✅ ${res.data.msg}</div>`;
+                appendLog('wrapper-logs', `<div class="log-ok">&gt; ✅ ${e(res.data.msg)}</div>`);
                 hide2FAModal();
             } else {
-                wrapperLogs.innerHTML += `<div style="color: #dc3545;">> ❌ ${res.data.msg}</div>`;
+                appendLog('wrapper-logs', `<div class="log-err">&gt; ❌ ${e(res.data.msg)}</div>`);
             }
-            wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
         })
-        .catch(err => {
-            wrapperLogs.innerHTML += `<div style="color: #dc3545;">> ❌ Failed to submit 2FA code</div>`;
-            wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
-        });
+        .catch(() => appendLog('wrapper-logs', '<div class="log-err">&gt; ❌ Failed to submit 2FA code</div>'));
 });
 
-// Cancel 2FA
-document.getElementById('cancel-2fa').addEventListener('click', function() {
+document.getElementById('cancel-2fa').addEventListener('click', () => {
     hide2FAModal();
-    const wrapperLogs = document.getElementById('wrapper-logs');
-    wrapperLogs.innerHTML += `<div style="color: #ffc107;">> ⚠️ 2FA cancelled by user</div>`;
-    wrapperLogs.scrollTop = wrapperLogs.scrollHeight;
+    appendLog('wrapper-logs', '<div class="log-warn">&gt; ⚠️ 2FA cancelled</div>');
 });
 
-// Allow Enter key to submit 2FA and validate input
-document.getElementById('twofa-code').addEventListener('keypress', function(e) {
-    if (e.key === 'Enter') {
-        document.getElementById('submit-2fa').click();
-    }
-    // Only allow numeric input
-    if (!/[0-9]/.test(e.key) && !['Enter', 'Backspace', 'Delete', 'Tab', 'Escape', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
-        e.preventDefault();
-    }
+document.getElementById('twofa-code').addEventListener('keydown', e => {
+    if (e.key === 'Enter') document.getElementById('submit-2fa').click();
 });
-
-// Format 2FA input as user types
-document.getElementById('twofa-code').addEventListener('input', function(e) {
-    // Remove any non-numeric characters
+document.getElementById('twofa-code').addEventListener('input', function () {
     this.value = this.value.replace(/[^0-9]/g, '');
 });
-
-// Close modal when clicking outside
-document.getElementById('twofa-modal').addEventListener('click', function(e) {
-    if (e.target === this) {
-        document.getElementById('cancel-2fa').click();
-    }
+document.getElementById('twofa-modal').addEventListener('click', function (ev) {
+    if (ev.target === this) document.getElementById('cancel-2fa').click();
 });
 </script>
 </body>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,17 +25,14 @@ services:
 
     # ── Volumes ───────────────────────────────────────────────────────────────
     volumes:
-      # Persist downloaded music files on the host.
-      # All three format folders (alac/atmos/aac) live under ./downloads.
+      # Downloaded music — all three format subdirs live here.
       - ./downloads:/downloads
 
-      # Persist the Go downloader config between container restarts.
-      # Remove this line if you prefer a fresh config every time.
-      - ./config:/app/apple-music-downloader/config-vol
+      # Persistent user data: credentials + Go downloader config.
+      # routes.py reads CREDENTIALS_PATH; the entrypoint seeds config.yaml
+      # into this directory on first run if it doesn't already exist.
+      - ./data:/data
 
-      # Persist saved login credentials (.credentials file) so auto-login
-      # survives container restarts.
-      - ./data:/app/data-vol
 
     # ── Restart policy ────────────────────────────────────────────────────────
     restart: unless-stopped
@@ -43,10 +40,10 @@ services:
     # ── Environment ───────────────────────────────────────────────────────────
     environment:
       - PYTHONUNBUFFERED=1
-      # Set to "production" to suppress Flask's debug output.
-      # Note: the Flask debug server is fine for personal/local use;
-      # for a production deployment consider gunicorn instead.
       - FLASK_ENV=development
+      # Tell routes.py where to persist the .credentials file so it survives
+      # container restarts (maps into the ./data bind-mount above).
+      - CREDENTIALS_PATH=/data/.credentials
 
     # ── Healthcheck ───────────────────────────────────────────────────────────
     healthcheck:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,64 @@
+# =============================================================================
+# docker-compose.yaml — Apple Music Downloader Web UI
+# =============================================================================
+#
+# Quick start:
+#   docker compose up --build           # first run (builds the image)
+#   docker compose up -d                # start in the background
+#   docker compose down                 # stop and remove the container
+#
+# The web UI is available at http://localhost:5000 once the container is up.
+# =============================================================================
+
+services:
+  alac-rip:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: alac-rip:latest
+    container_name: alac-rip
+
+    # ── Port mapping ──────────────────────────────────────────────────────────
+    # Change the left-hand side to use a different host port, e.g. "8080:5000"
+    ports:
+      - "5000:5000"
+
+    # ── Volumes ───────────────────────────────────────────────────────────────
+    volumes:
+      # Persist downloaded music files on the host.
+      # All three format folders (alac/atmos/aac) live under ./downloads.
+      - ./downloads:/downloads
+
+      # Persist the Go downloader config between container restarts.
+      # Remove this line if you prefer a fresh config every time.
+      - ./config:/app/apple-music-downloader/config-vol
+
+      # Persist saved login credentials (.credentials file) so auto-login
+      # survives container restarts.
+      - ./data:/app/data-vol
+
+    # ── Restart policy ────────────────────────────────────────────────────────
+    restart: unless-stopped
+
+    # ── Environment ───────────────────────────────────────────────────────────
+    environment:
+      - PYTHONUNBUFFERED=1
+      # Set to "production" to suppress Flask's debug output.
+      # Note: the Flask debug server is fine for personal/local use;
+      # for a production deployment consider gunicorn instead.
+      - FLASK_ENV=development
+
+    # ── Healthcheck ───────────────────────────────────────────────────────────
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+    # ── Logging ───────────────────────────────────────────────────────────────
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -71,7 +71,23 @@ else
 fi
 
 # ── Default config.yaml ────────────────────────────────────────────────────────
+# If the /data volume is mounted (docker-compose), keep config there so it
+# persists across container recreations and symlink it into the expected path.
+# Fall back to writing directly in the apple-music-downloader directory.
 CONFIG_FILE="/app/apple-music-downloader/config.yaml"
+if [ -d "/data" ]; then
+    PERSISTENT_CONFIG="/data/config.yaml"
+    if [ -f "$PERSISTENT_CONFIG" ] && [ ! -f "$CONFIG_FILE" ]; then
+        info "Linking persistent config from /data/config.yaml"
+        ln -sf "$PERSISTENT_CONFIG" "$CONFIG_FILE"
+    elif [ ! -f "$PERSISTENT_CONFIG" ] && [ -f "$CONFIG_FILE" ]; then
+        info "Moving config to /data for persistence"
+        mv "$CONFIG_FILE" "$PERSISTENT_CONFIG"
+        ln -sf "$PERSISTENT_CONFIG" "$CONFIG_FILE"
+    elif [ ! -f "$PERSISTENT_CONFIG" ] && [ ! -f "$CONFIG_FILE" ]; then
+        CONFIG_FILE="$PERSISTENT_CONFIG"  # write directly to /data
+    fi
+fi
 
 if [ ! -f "$CONFIG_FILE" ]; then
     section "Creating default config.yaml"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# =============================================================================
+# docker-entrypoint.sh
+# Container startup script for the Apple Music Downloader Web UI.
+#
+# Responsibilities:
+#   1. Verify that the required tooling is in PATH.
+#   2. Create a sensible default config.yaml the very first time the container
+#      runs (pointing download folders at the /downloads volume).
+#   3. Print a startup banner with usage notes and the legal disclaimer.
+#   4. Hand control to main.py which starts the Flask web server.
+# =============================================================================
+
+set -e
+
+# ── Colour helpers ─────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+
+info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+section() { echo -e "\n${CYAN}${BOLD}==> $*${NC}"; }
+
+# ── PATH sanity check ──────────────────────────────────────────────────────────
+section "Checking toolchain"
+
+# Verify wrapper binary
+WRAPPER_BIN="/app/wrapper/wrapper"
+if [ ! -x "$WRAPPER_BIN" ]; then
+    # One more attempt: search under /app/wrapper for any executable
+    FOUND=$(find /app/wrapper -maxdepth 2 -type f -executable | head -1)
+    if [ -n "$FOUND" ]; then
+        warn "Expected '$WRAPPER_BIN' but found '$FOUND'. Creating symlink."
+        ln -sf "$FOUND" "$WRAPPER_BIN"
+    else
+        warn "Wrapper binary not found at $WRAPPER_BIN — login will fail."
+    fi
+else
+    info "wrapper  : OK ($WRAPPER_BIN)"
+fi
+
+# Verify Bento4
+BENTO4_CHECK=$(command -v mp4info 2>/dev/null || true)
+if [ -z "$BENTO4_CHECK" ]; then
+    # Try to find and add it dynamically
+    BENTO4_BIN_DIR=$(find /app/bento4 -maxdepth 2 -type d -name "bin" | head -1)
+    if [ -n "$BENTO4_BIN_DIR" ]; then
+        export PATH="$BENTO4_BIN_DIR:$PATH"
+        info "Bento4   : OK (added $BENTO4_BIN_DIR to PATH)"
+    else
+        warn "Bento4 bin directory not found — media processing may fail."
+    fi
+else
+    info "Bento4   : OK ($BENTO4_CHECK)"
+fi
+
+# Verify Go
+GO_BIN=$(command -v go 2>/dev/null || true)
+if [ -z "$GO_BIN" ]; then
+    warn "Go toolchain not found in PATH — downloads will not work."
+else
+    info "go       : OK ($(go version | awk '{print $3}'))"
+fi
+
+# Verify ffmpeg
+FFMPEG_BIN=$(command -v ffmpeg 2>/dev/null || true)
+if [ -z "$FFMPEG_BIN" ]; then
+    warn "ffmpeg not found — audio conversion will not work."
+else
+    info "ffmpeg   : OK ($FFMPEG_BIN)"
+fi
+
+# ── Default config.yaml ────────────────────────────────────────────────────────
+CONFIG_FILE="/app/apple-music-downloader/config.yaml"
+
+if [ ! -f "$CONFIG_FILE" ]; then
+    section "Creating default config.yaml"
+    mkdir -p "$(dirname "$CONFIG_FILE")"
+    cat > "$CONFIG_FILE" << 'YAML_EOF'
+# ── Authentication ────────────────────────────────────────────────────────────
+# These tokens are managed automatically by the Wrapper login flow.
+# You can also paste them manually here if needed.
+media-user-token: ""
+authorization-token: ""
+
+# ── Regional ──────────────────────────────────────────────────────────────────
+language: en-US
+storefront: us
+
+# ── Download folders (mapped to the /downloads Docker volume) ─────────────────
+alac-save-folder: /downloads/alac
+atmos-save-folder: /downloads/atmos
+aac-save-folder: /downloads/aac
+
+# ── Quality ───────────────────────────────────────────────────────────────────
+aac-type: aac
+alac-max: 192000
+atmos-max: 2768
+limit-max: 200
+
+# ── Cover art ─────────────────────────────────────────────────────────────────
+cover-size: 5000x5000bb
+cover-format: jpg
+embed-cover: true
+save-artist-cover: false
+save-animated-artwork: false
+emby-animated-artwork: false
+
+# ── Lyrics ────────────────────────────────────────────────────────────────────
+lrc-type: lyrics
+lrc-format: lrc
+embed-lrc: false
+save-lrc-file: false
+
+# ── File naming ───────────────────────────────────────────────────────────────
+album-folder-format: "{ArtistName}/{AlbumName}"
+playlist-folder-format: "{PlaylistName}"
+song-file-format: "{SongNumer}. {SongName}"
+artist-folder-format: ""
+
+# ── Tags ──────────────────────────────────────────────────────────────────────
+explicit-choice: "[E]"
+clean-choice: "[C]"
+apple-master-choice: "[M]"
+use-songinfo-for-playlist: false
+dl-albumcover-for-playlist: false
+
+# ── Conversion ────────────────────────────────────────────────────────────────
+convert-after-download: false
+convert-format: flac
+convert-keep-original: false
+convert-skip-if-source-matches: false
+ffmpeg-path: ffmpeg
+convert-extra-args: ""
+
+# ── Advanced ──────────────────────────────────────────────────────────────────
+max-memory-limit: 256
+decrypt-m3u8-port: "127.0.0.1:10020"
+get-m3u8-port: "127.0.0.1:20020"
+get-m3u8-mode: hires
+mv-audio-type: atmos
+mv-max: 2160
+get-m3u8-from-device: false
+YAML_EOF
+    info "Default config.yaml created at $CONFIG_FILE"
+    info "You can edit settings via the web UI at http://localhost:5000/settings"
+else
+    info "config   : OK (found existing $CONFIG_FILE)"
+fi
+
+# ── Startup banner ─────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        Apple Music Downloader Web UI — Docker Edition        ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  Web UI  : ${GREEN}http://localhost:5000${NC}"
+echo -e "  Settings: ${GREEN}http://localhost:5000/settings${NC}"
+echo ""
+echo -e "  Downloads are saved to the ${CYAN}/downloads${NC} volume:"
+echo -e "    ALAC  → /downloads/alac"
+echo -e "    Atmos → /downloads/atmos"
+echo -e "    AAC   → /downloads/aac"
+echo ""
+echo -e "${YELLOW}LEGAL DISCLAIMER:${NC}"
+echo "  This tool is intended ONLY for accessing content you are legally"
+echo "  entitled to (e.g. your own Apple Music subscription). Downloading"
+echo "  copyrighted material without authorisation may violate Apple's"
+echo "  Terms of Service and applicable laws. Use responsibly."
+echo ""
+
+# ── Hand off to main.py ────────────────────────────────────────────────────────
+# main.py detects the 'firstrun' marker and calls start() directly,
+# which sets PATH for Bento4/wrapper and launches Flask on 0.0.0.0:5000.
+exec python3 /app/main.py


### PR DESCRIPTION
….dockerignore

Implements the containerised option for the Apple Music Downloader Web UI.

- Dockerfile: ubuntu:22.04 base; installs ffmpeg, gpac, golang-go, Python deps; downloads Bento4 SDK and the Wrapper binary; clones the Go downloader; pre-warms Go module cache; creates the firstrun marker so main.py skips setup; exposes port 5000 and declares /downloads as a named volume.

- docker-entrypoint.sh: verifies toolchain at startup, writes a default config.yaml (with download folders mapped to /downloads) on first run, prints a disclaimer banner, then hands off to main.py.

- docker-compose.yaml: single-service compose file; maps port 5000, mounts ./downloads, ./config, and ./data for persistence; adds a healthcheck.

- .dockerignore: excludes bento4/, wrapper/, apple-music-downloader/ (fetched fresh by Docker), credentials, pyc files, and editor/OS noise.

Closes the portable-app vs Docker decision: the portable Windows app was not selected because the Wrapper release ships a Linux ELF x86_64 binary only, and Bento4 also requires a Linux runtime. Docker is the natural fit.

https://claude.ai/code/session_019CqyaXcN1uH5e39hUg2dvD